### PR TITLE
fix: restore ESLint imports and CI/deploy gaps from slop cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -689,7 +689,7 @@ jobs:
           fi
 
           # Scripts 目录（如果存在）
-          if [ -d "../public/Scripts" ]; then
+          if [ -d "public/Scripts" ]; then
             SYNC_PATHS="$SYNC_PATHS Scripts/"
             SYNC_DESC="$SYNC_DESC+scripts"
           fi

--- a/Build/__tests__/reliability.test.ts
+++ b/Build/__tests__/reliability.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 
 describe('fetch-retry dispatcher wiring', () => {
   it('dispatcher is exported and not undefined', () => {

--- a/Build/build-public.ts
+++ b/Build/build-public.ts
@@ -60,7 +60,7 @@ export const buildPublic = task(
       span,
       [
         '# NRRule - Surge / Clash 规则部署仓库',
-        '# 源码位于 [lucking7/esdeath](https://github.com/lucking7/MirrRule)',
+        '# 源码位于 [lucking7/MirrRule](https://github.com/lucking7/MirrRule)',
         '',
         '![GitHub repo size](https://img.shields.io/github/repo-size/lucking7/NRRule?style=flat-square)',
       ],

--- a/Build/download-previous-build.ts
+++ b/Build/download-previous-build.ts
@@ -13,9 +13,9 @@ import { extract as tarExtract } from 'tar-fs';
 import { isCI } from 'ci-info';
 import { headStatus } from './lib/tarball-utils.ts';
 
-const GITHUB_CODELOAD_URL = 'https://codeload.github.com/lucking7/NRRule/tar.gz/master';
+const GITHUB_CODELOAD_URL = 'https://codeload.github.com/lucking7/NRRule/tar.gz/main';
 const GITLAB_CODELOAD_URL =
-  'https://gitlab.com/lucking7/NRRule/-/archive/master/NRRule-master.tar.gz';
+  'https://gitlab.com/lucking7/NRRule/-/archive/main/NRRule-main.tar.gz';
 
 export const downloadPreviousBuild = task(
   require.main === module,
@@ -65,7 +65,7 @@ export const downloadPreviousBuild = task(
       )
       .end();
 
-    const pathPrefix = 'ruleset.skk.moe-master/';
+    const pathPrefix = 'NRRule-main/';
 
     return pipeline(
       respBody,

--- a/Build/integration/mirror-sync/github-api.ts
+++ b/Build/integration/mirror-sync/github-api.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import process from 'node:process';
 
 import { $$fetch, defaultRequestInit } from '../../utils/network/fetch-retry';

--- a/Build/integration/mirror-sync/sync-engine.ts
+++ b/Build/integration/mirror-sync/sync-engine.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createHash } from 'node:crypto';

--- a/Build/validate-domain-alive.ts
+++ b/Build/validate-domain-alive.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import process from 'node:process';
 import picocolors from 'picocolors';
 import { task } from './trace';
 import { getMethods } from './utils/domain/is-domain-alive';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores CI **Build & Deploy** after consecutive failures since `a1c39f6` (slop cleanup removed `node:buffer` / `node:process` imports while code still uses `Buffer` / `process`, triggering ESLint `n/prefer-global/*` errors in `pnpm run validate`).

Also addresses three issues found during a full-repo review.

## Changes

### CI blocker (ESLint)
- `Build/integration/mirror-sync/sync-engine.ts` — `import { Buffer } from 'node:buffer'`
- `Build/integration/mirror-sync/github-api.ts` — `import { Buffer } from 'node:buffer'`
- `Build/validate-domain-alive.ts` — `import process from 'node:process'`
- `Build/__tests__/reliability.test.ts` — `import process from 'node:process'`

### Deploy / docs (from review)
- `.github/workflows/main.yml` — fix Scripts sync path (`public/Scripts` instead of `../public/Scripts`)
- `Build/build-public.ts` — README link text `lucking7/MirrRule` (was stale `esdeath` label)
- `Build/download-previous-build.ts` — use `main` branch + `NRRule-main/` tar prefix (was `master` / `ruleset.skk.moe-master/`)

## Verification

- `pnpm run validate` — 0 errors (150 warnings, pre-existing)
- `pnpm test` — 10/10 pass

## Follow-up (not in this PR)

Review flagged additional improvements worth separate PRs:
- Remove `continue-on-error: true` on `deploy-github` so NRRule push failures fail the workflow
- Fail plugin convert / module merge when outputs are missing (currently silent)
- Expand tests beyond `reliability.test.ts` smoke coverage
- Align deploy `if` with `master` branch or drop `master` from triggers

## Test plan

- [x] `pnpm run validate`
- [x] `pnpm test`
- [ ] Merge and confirm **Build & Deploy** on `main` goes green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5c7abf2-8097-4758-b843-3f2550a3bdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5c7abf2-8097-4758-b843-3f2550a3bdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

