### PR TITLE
ci: isolate Script-Hub from build-only runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,20 +172,176 @@ jobs:
           echo "  Deploy: $DEPLOY (target: $DEPLOY_TARGET)"
 
   # ============================================
-  # 核心构建任务 - 包含所有生成步骤
+  # 插件转换任务 - 只有需要插件转换时才启动 Script-Hub
   # ============================================
-  build:
-    name: Build
+  convert-plugins:
+    name: Convert Plugins
     needs: prepare
-    if: needs.prepare.outputs.should_build == 'true'
+    if: needs.prepare.outputs.should_convert_plugins == 'true'
     runs-on: ubuntu-latest
     services:
-      # 🔧 添加 Script-Hub 服务（用于插件转换）
       script-hub:
         image: xream/script-hub:latest
         ports:
           - 9100:9100
           - 9101:9101
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Setup plugin output directories
+        run: mkdir -p public/Modules/Converted public/Scripts
+
+      - name: Configure Script-Hub
+        run: |
+          echo "127.0.0.1 script.hub" | sudo tee -a /etc/hosts
+          echo "⏳ 等待 Script-Hub 服务启动..."
+          for i in {1..30}; do
+            if curl -f -s http://script.hub:9101/ > /dev/null 2>&1; then
+              echo "✓ Script-Hub 服务就绪 (尝试 $i/30)"
+              sleep 10
+              exit 0
+            fi
+            echo "  尝试 $i/30 失败，等待 5 秒后重试..."
+            sleep 5
+          done
+          echo "❌ Script-Hub 服务启动超时"
+          exit 1
+
+      - name: Convert plugins
+        continue-on-error: true
+        run: |
+          pnpm run convert-plugins --wait-service --timeout 600 || {
+            echo "⚠️ 首次转换失败，等待 10 秒后重试..."
+            sleep 10
+            pnpm run convert-plugins --wait-service --timeout 600 || {
+              echo "❌ 两次转换都失败，继续构建流程"
+            }
+          }
+        env:
+          CI: true
+          PROXY_BASE: ${{ secrets.PROXY_BASE }}
+
+      - name: Upload plugin conversion output
+        uses: actions/upload-artifact@v7
+        with:
+          name: plugin-output-${{ github.sha }}-${{ github.run_number }}
+          path: |
+            public/Modules/Converted
+            public/Scripts
+          retention-days: 1
+          compression-level: 4
+          if-no-files-found: warn
+
+  # ============================================
+  # 模块合并任务 - 不需要 Script-Hub 服务
+  # ============================================
+  merge-modules:
+    name: Merge Modules
+    needs: [prepare, convert-plugins]
+    if: |
+      always() &&
+      needs.prepare.outputs.should_merge_modules == 'true' &&
+      (needs.convert-plugins.result == 'success' || needs.convert-plugins.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Setup module output directories
+        run: mkdir -p public/Modules/Converted public/Modules/Merged public/Modules/Rules public/Scripts
+
+      - name: Download plugin conversion output
+        if: needs.prepare.outputs.should_convert_plugins == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: plugin-output-${{ github.sha }}-${{ github.run_number }}
+          path: public
+
+      - name: Ensure converted modules exist
+        if: needs.prepare.outputs.should_convert_plugins != 'true'
+        run: |
+          CONVERTED_DIR="public/Modules/Converted"
+          if [ -d "$CONVERTED_DIR" ]; then
+            FILE_COUNT=$(find "$CONVERTED_DIR" -type f -name '*.sgmodule' 2>/dev/null | wc -l)
+          else
+            FILE_COUNT=0
+          fi
+
+          if [ "$FILE_COUNT" -gt 0 ]; then
+            echo "✅ 已有 $FILE_COUNT 个转换后的模块文件，无需下载"
+            exit 0
+          fi
+
+          echo "📥 转换后的模块文件缺失，从生产环境下载..."
+          git clone --depth=1 --filter=blob:none --sparse \
+            https://github.com/lucking7/NRRule.git ./temp-converted 2>/dev/null || {
+            echo "⚠️ 无法下载生产环境的模块文件，模块合并可能失败"
+            exit 0
+          }
+          cd ./temp-converted
+          git sparse-checkout set Modules/Converted
+          cd ..
+
+          mkdir -p "$CONVERTED_DIR"
+          if [ -d "temp-converted/Modules/Converted" ]; then
+            cp -r temp-converted/Modules/Converted/* "$CONVERTED_DIR/" 2>/dev/null || true
+            echo "✅ 从生产环境下载了 $(find "$CONVERTED_DIR" -type f -name '*.sgmodule' 2>/dev/null | wc -l) 个模块文件"
+          fi
+          rm -rf ./temp-converted
+
+      - name: Merge modules
+        run: |
+          mkdir -p public/Modules/Rules
+          pnpm run node ./Build/merge-modules.ts --config Build/lib/module-merger/configs/pro-merge-config.yaml
+        env:
+          CI: true
+
+      - name: Upload module output
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-output-${{ github.sha }}-${{ github.run_number }}
+          path: |
+            public/Modules
+            public/Scripts
+          retention-days: 1
+          compression-level: 4
+          if-no-files-found: warn
+
+  # ============================================
+  # 核心构建任务 - 包含规则生成与最终产物
+  # ============================================
+  build:
+    name: Build
+    needs: [prepare, convert-plugins, merge-modules]
+    if: |
+      always() &&
+      needs.prepare.outputs.should_build == 'true' &&
+      (needs.convert-plugins.result == 'success' || needs.convert-plugins.result == 'skipped') &&
+      (needs.merge-modules.result == 'success' || needs.merge-modules.result == 'skipped')
+    runs-on: ubuntu-latest
     steps:
       # 🚀 网络性能优化
       - uses: smorimoto/tune-github-hosted-runner-network@v1
@@ -263,84 +419,24 @@ jobs:
         env:
           CI: true
 
-      # 🔧 步骤 2: 插件转换（如果需要）
+      - name: Download plugin conversion output
+        if: |
+          needs.prepare.outputs.should_convert_plugins == 'true' &&
+          needs.prepare.outputs.should_merge_modules != 'true' &&
+          needs.convert-plugins.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: plugin-output-${{ github.sha }}-${{ github.run_number }}
+          path: public
 
-      # 🔧 步骤 3: 插件转换（如果需要）
-      - name: Configure Script-Hub
-        if: needs.prepare.outputs.should_convert_plugins == 'true'
-        run: |
-          echo "127.0.0.1 script.hub" | sudo tee -a /etc/hosts
-          echo "⏳ 等待 Script-Hub 服务启动..."
-          for i in {1..30}; do
-            if curl -f -s http://script.hub:9101/ > /dev/null 2>&1; then
-              echo "✓ Script-Hub 服务就绪 (尝试 $i/30)"
-              sleep 10
-              exit 0
-            fi
-            echo "  尝试 $i/30 失败，等待 5 秒后重试..."
-            sleep 5
-          done
-          echo "❌ Script-Hub 服务启动超时"
-          exit 1
-
-      - name: Convert plugins
-        if: needs.prepare.outputs.should_convert_plugins == 'true'
-        continue-on-error: true
-        run: |
-          pnpm run convert-plugins --wait-service --timeout 600 || {
-            echo "⚠️ 首次转换失败，等待 10 秒后重试..."
-            sleep 10
-            pnpm run convert-plugins --wait-service --timeout 600 || {
-              echo "❌ 两次转换都失败，继续构建流程"
-            }
-          }
-        env:
-          CI: true
-          PROXY_BASE: ${{ secrets.PROXY_BASE }}
-
-      # 🔧 步骤 3.5: 确保转换后的模块文件存在（当跳过插件转换时从生产环境下载）
-      - name: Ensure converted modules exist
+      - name: Download module output
         if: |
           needs.prepare.outputs.should_merge_modules == 'true' &&
-          needs.prepare.outputs.should_convert_plugins != 'true'
-        run: |
-          CONVERTED_DIR="public/Modules/Converted"
-          if [ -d "$CONVERTED_DIR" ]; then
-            FILE_COUNT=$(find "$CONVERTED_DIR" -type f -name '*.sgmodule' 2>/dev/null | wc -l)
-          else
-            FILE_COUNT=0
-          fi
-
-          if [ "$FILE_COUNT" -gt 0 ]; then
-            echo "✅ 已有 $FILE_COUNT 个转换后的模块文件，无需下载"
-            exit 0
-          fi
-
-          echo "📥 转换后的模块文件缺失，从生产环境下载..."
-          git clone --depth=1 --filter=blob:none --sparse \
-            https://github.com/lucking7/NRRule.git ./temp-converted 2>/dev/null || {
-            echo "⚠️ 无法下载生产环境的模块文件，模块合并可能失败"
-            exit 0
-          }
-          cd ./temp-converted
-          git sparse-checkout set Modules/Converted
-          cd ..
-
-          mkdir -p "$CONVERTED_DIR"
-          if [ -d "temp-converted/Modules/Converted" ]; then
-            cp -r temp-converted/Modules/Converted/* "$CONVERTED_DIR/" 2>/dev/null || true
-            echo "✅ 从生产环境下载了 $(find "$CONVERTED_DIR" -type f -name '*.sgmodule' 2>/dev/null | wc -l) 个模块文件"
-          fi
-          rm -rf ./temp-converted
-
-      # 🔧 步骤 4: 模块合并（如果需要）
-      - name: Merge modules
-        if: needs.prepare.outputs.should_merge_modules == 'true'
-        run: |
-          mkdir -p public/Modules/Rules
-          pnpm run node ./Build/merge-modules.ts --config Build/lib/module-merger/configs/pro-merge-config.yaml
-        env:
-          CI: true
+          needs.merge-modules.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: module-output-${{ github.sha }}-${{ github.run_number }}
+          path: public
 
       # 🔧 步骤 4.2: 清理 Modules 根目录中的历史 .sgmodule 文件
       - name: Clean legacy Modules root files

--- a/Build/__tests__/workflow-contract.test.ts
+++ b/Build/__tests__/workflow-contract.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { describe, it } from 'node:test';
+import { parse } from 'yaml';
+
+interface WorkflowStep {
+  name?: string;
+  uses?: string;
+  if?: string;
+  with?: Record<string, unknown>;
+}
+
+interface WorkflowJob {
+  name?: string;
+  needs?: string | string[];
+  if?: string;
+  services?: Record<string, { image?: string }>;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const workflowPath = path.join(process.cwd(), '.github', 'workflows', 'main.yml');
+const workflow = parse(fs.readFileSync(workflowPath, 'utf8')) as Workflow;
+
+function getJob(id: string) {
+  const job = workflow.jobs?.[id];
+  assert.ok(job, `job ${id} should exist`);
+  return job;
+}
+
+function getNeeds(job: WorkflowJob) {
+  if (Array.isArray(job.needs)) return job.needs;
+  if (typeof job.needs === 'string') return [job.needs];
+  return [];
+}
+
+function hasStep(job: WorkflowJob, name: string) {
+  return job.steps?.some(step => step.name === name) ?? false;
+}
+
+describe('GitHub Actions workflow contract', () => {
+  it('keeps Script-Hub out of the generic Build job', () => {
+    const buildJob = getJob('build');
+
+    assert.equal(buildJob.services?.['script-hub'], undefined);
+    assert.ok(getNeeds(buildJob).includes('convert-plugins'));
+    assert.ok(getNeeds(buildJob).includes('merge-modules'));
+
+    const condition = buildJob.if ?? '';
+    assert.match(condition, /always\(\)/);
+    assert.match(condition, /needs\.prepare\.outputs\.should_build == 'true'/);
+    assert.match(condition, /needs\.convert-plugins\.result == 'success'/);
+    assert.match(condition, /needs\.convert-plugins\.result == 'skipped'/);
+    assert.match(condition, /needs\.merge-modules\.result == 'success'/);
+    assert.match(condition, /needs\.merge-modules\.result == 'skipped'/);
+  });
+
+  it('runs Script-Hub only in the plugin conversion job', () => {
+    const convertJob = getJob('convert-plugins');
+
+    assert.equal(convertJob.services?.['script-hub']?.image, 'xream/script-hub:latest');
+    assert.match(convertJob.if ?? '', /should_convert_plugins == 'true'/);
+    assert.equal(hasStep(convertJob, 'Configure Script-Hub'), true);
+    assert.equal(hasStep(convertJob, 'Convert plugins'), true);
+    assert.equal(hasStep(convertJob, 'Upload plugin conversion output'), true);
+  });
+
+  it('merges modules without starting a Script-Hub service', () => {
+    const mergeJob = getJob('merge-modules');
+
+    assert.equal(mergeJob.services?.['script-hub'], undefined);
+    assert.ok(getNeeds(mergeJob).includes('convert-plugins'));
+    assert.match(mergeJob.if ?? '', /always\(\)/);
+    assert.match(mergeJob.if ?? '', /should_merge_modules == 'true'/);
+    assert.match(mergeJob.if ?? '', /needs\.convert-plugins\.result == 'success'/);
+    assert.match(mergeJob.if ?? '', /needs\.convert-plugins\.result == 'skipped'/);
+    assert.equal(hasStep(mergeJob, 'Download plugin conversion output'), true);
+    assert.equal(hasStep(mergeJob, 'Ensure converted modules exist'), true);
+    assert.equal(hasStep(mergeJob, 'Merge modules'), true);
+    assert.equal(hasStep(mergeJob, 'Upload module output'), true);
+  });
+});


### PR DESCRIPTION
## Summary

Build-only workflow runs no longer depend on Docker Hub availability for Script-Hub. Script-Hub now starts only in the plugin conversion job, while the final Build job stays service-free and consumes plugin/module outputs through short-lived artifacts.

This keeps fast update, PR, and build-only runs from failing before checkout when `xream/script-hub:latest` has a transient pull timeout. Module merge remains supported without starting Script-Hub, and skipped optional jobs are explicitly allowed so the final Build job still runs when plugin work is not requested.

## Testing

- `pnpm run node --test Build/__tests__/workflow-contract.test.ts`
- `pnpm test`
- `pnpm run validate`
- `pnpm run knip`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
