### PR TITLE
ci: keep plugin artifact available for module merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,11 +233,19 @@ jobs:
           CI: true
           PROXY_BASE: ${{ secrets.PROXY_BASE }}
 
+      - name: Prepare plugin artifact marker
+        if: always()
+        run: |
+          mkdir -p public/.artifacts
+          printf 'plugin-output-ready\n' > public/.artifacts/plugin-output-ready
+
       - name: Upload plugin conversion output
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: plugin-output-${{ github.sha }}-${{ github.run_number }}
           path: |
+            public/.artifacts
             public/Modules/Converted
             public/Scripts
           retention-days: 1
@@ -281,7 +289,6 @@ jobs:
           path: public
 
       - name: Ensure converted modules exist
-        if: needs.prepare.outputs.should_convert_plugins != 'true'
         run: |
           CONVERTED_DIR="public/Modules/Converted"
           if [ -d "$CONVERTED_DIR" ]; then

--- a/Build/__tests__/workflow-contract.test.ts
+++ b/Build/__tests__/workflow-contract.test.ts
@@ -43,6 +43,12 @@ function hasStep(job: WorkflowJob, name: string) {
   return job.steps?.some(step => step.name === name) ?? false;
 }
 
+function getStep(job: WorkflowJob, name: string) {
+  const step = job.steps?.find(item => item.name === name);
+  assert.ok(step, `step ${name} should exist`);
+  return step;
+}
+
 describe('GitHub Actions workflow contract', () => {
   it('keeps Script-Hub out of the generic Build job', () => {
     const buildJob = getJob('build');
@@ -67,7 +73,12 @@ describe('GitHub Actions workflow contract', () => {
     assert.match(convertJob.if ?? '', /should_convert_plugins == 'true'/);
     assert.equal(hasStep(convertJob, 'Configure Script-Hub'), true);
     assert.equal(hasStep(convertJob, 'Convert plugins'), true);
+    assert.equal(hasStep(convertJob, 'Prepare plugin artifact marker'), true);
     assert.equal(hasStep(convertJob, 'Upload plugin conversion output'), true);
+
+    const uploadStep = getStep(convertJob, 'Upload plugin conversion output');
+    assert.match(String(uploadStep.if), /always\(\)/);
+    assert.match(String(uploadStep.with?.path), /public\/.artifacts/);
   });
 
   it('merges modules without starting a Script-Hub service', () => {
@@ -81,6 +92,10 @@ describe('GitHub Actions workflow contract', () => {
     assert.match(mergeJob.if ?? '', /needs\.convert-plugins\.result == 'skipped'/);
     assert.equal(hasStep(mergeJob, 'Download plugin conversion output'), true);
     assert.equal(hasStep(mergeJob, 'Ensure converted modules exist'), true);
+
+    const ensureStep = getStep(mergeJob, 'Ensure converted modules exist');
+    assert.equal(ensureStep.if, undefined);
+
     assert.equal(hasStep(mergeJob, 'Merge modules'), true);
     assert.equal(hasStep(mergeJob, 'Upload module output'), true);
   });


### PR DESCRIPTION
## Summary

Module merge no longer fails when plugin conversion produces no uploadable module files. The plugin conversion job now always uploads a small marker artifact, and the module merge job always checks whether converted modules are present before merging so it can fall back to production modules when needed.

This fixes the post-merge push workflow failure from #347, where `Merge Modules` could not download `plugin-output-*` because `actions/upload-artifact` skipped creation for empty paths.

## Testing

- `pnpm run node --test Build/__tests__/workflow-contract.test.ts`
- `pnpm test`
- `pnpm run validate`
- `pnpm run knip`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
