### PR TITLE
ci: use non-hidden plugin artifact marker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,8 +236,8 @@ jobs:
       - name: Prepare plugin artifact marker
         if: always()
         run: |
-          mkdir -p public/.artifacts
-          printf 'plugin-output-ready\n' > public/.artifacts/plugin-output-ready
+          mkdir -p public/_artifacts
+          printf 'plugin-output-ready\n' > public/_artifacts/plugin-output-ready
 
       - name: Upload plugin conversion output
         if: always()
@@ -245,7 +245,7 @@ jobs:
         with:
           name: plugin-output-${{ github.sha }}-${{ github.run_number }}
           path: |
-            public/.artifacts
+            public/_artifacts
             public/Modules/Converted
             public/Scripts
           retention-days: 1

--- a/Build/__tests__/workflow-contract.test.ts
+++ b/Build/__tests__/workflow-contract.test.ts
@@ -78,7 +78,7 @@ describe('GitHub Actions workflow contract', () => {
 
     const uploadStep = getStep(convertJob, 'Upload plugin conversion output');
     assert.match(String(uploadStep.if), /always\(\)/);
-    assert.match(String(uploadStep.with?.path), /public\/.artifacts/);
+    assert.match(String(uploadStep.with?.path), /public\/_artifacts/);
   });
 
   it('merges modules without starting a Script-Hub service', () => {


### PR DESCRIPTION
## Summary
- move the plugin-output fallback marker from hidden public/.artifacts to public/_artifacts
- keep the workflow contract test aligned with the non-hidden marker path

## Why
- actions/upload-artifact@v7 defaults include-hidden-files to false, so the previous hidden marker was ignored and no plugin-output artifact was created when plugin conversion produced no files

## Verification
- pnpm run node --test Build/__tests__/workflow-contract.test.ts
- pnpm test
- pnpm run validate
- pnpm run knip
- git diff --check